### PR TITLE
Add Function and Nil types

### DIFF
--- a/src/glerd.gleam
+++ b/src/glerd.gleam
@@ -1,8 +1,10 @@
 import fswalk.{Entry, Stat}
 import glance.{
-  CustomType, Definition, Field, Module, NamedType, TupleType, Variant,
+  CustomType, Definition, Field, FunctionType, Module, NamedType, TupleType,
+  Variant,
 }
 import gleam/dict.{type Dict}
+import gleam/io
 import gleam/iterator
 import gleam/list
 import gleam/option.{Some}
@@ -166,6 +168,7 @@ fn field_type(typ) {
     NamedType(type_name, ..) if type_name == "Int" -> "types.IsInt"
     NamedType(type_name, ..) if type_name == "Float" -> "types.IsFloat"
     NamedType(type_name, ..) if type_name == "Bool" -> "types.IsBool"
+    NamedType(type_name, ..) if type_name == "Nil" -> "types.IsNil"
     NamedType(type_name, _, [typ]) if type_name == "List" ->
       "types.IsList(" <> field_type(typ) <> ")"
     NamedType(type_name, _, [key_type, val_type]) if type_name == "Dict" ->
@@ -187,7 +190,48 @@ fn field_type(typ) {
       <> type_args([typ1, typ2, typ3, typ4, typ5, typ6])
       <> ")"
     NamedType(record_name, ..) -> "types.IsRecord(\"" <> record_name <> "\")"
-    _ -> "types.Unknown"
+    FunctionType([], return) ->
+      "types.IsFunction0(\"" <> field_type(return) <> "\")"
+    FunctionType([typ1], return) ->
+      "types.IsFunction1("
+      <> type_args([typ1])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    FunctionType([typ1, typ2], return) ->
+      "types.IsFunction2("
+      <> type_args([typ1, typ2])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    FunctionType([typ1, typ2, typ3], return) ->
+      "types.IsFunction3("
+      <> type_args([typ1, typ2, typ3])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    FunctionType([typ1, typ2, typ3, typ4], return) ->
+      "types.IsFunction4("
+      <> type_args([typ1, typ2, typ3, typ4])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    FunctionType([typ1, typ2, typ3, typ4, typ5], return) ->
+      "types.IsFunction5("
+      <> type_args([typ1, typ2, typ3, typ4, typ5])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    FunctionType([typ1, typ2, typ3, typ4, typ5, typ6], return) ->
+      "types.IsFunction6("
+      <> type_args([typ1, typ2, typ3, typ4, typ5, typ6])
+      <> ", "
+      <> field_type(return)
+      <> ")"
+    _ -> {
+      io.debug(typ)
+      "types.Unknown"
+    }
   }
 }
 

--- a/src/glerd.gleam
+++ b/src/glerd.gleam
@@ -191,42 +191,22 @@ fn field_type(typ) {
       <> ")"
     NamedType(record_name, ..) -> "types.IsRecord(\"" <> record_name <> "\")"
     FunctionType([], return) ->
-      "types.IsFunction0(\"" <> field_type(return) <> "\")"
+      "types.IsFunction0(" <> type_args([return]) <> ")"
     FunctionType([typ1], return) ->
-      "types.IsFunction1("
-      <> type_args([typ1])
-      <> ", "
-      <> field_type(return)
-      <> ")"
+      "types.IsFunction1(" <> type_args([typ1, return]) <> ")"
     FunctionType([typ1, typ2], return) ->
-      "types.IsFunction2("
-      <> type_args([typ1, typ2])
-      <> ", "
-      <> field_type(return)
-      <> ")"
+      "types.IsFunction2(" <> type_args([typ1, typ2, return]) <> ")"
     FunctionType([typ1, typ2, typ3], return) ->
-      "types.IsFunction3("
-      <> type_args([typ1, typ2, typ3])
-      <> ", "
-      <> field_type(return)
-      <> ")"
+      "types.IsFunction3(" <> type_args([typ1, typ2, typ3, return]) <> ")"
     FunctionType([typ1, typ2, typ3, typ4], return) ->
-      "types.IsFunction4("
-      <> type_args([typ1, typ2, typ3, typ4])
-      <> ", "
-      <> field_type(return)
-      <> ")"
+      "types.IsFunction4(" <> type_args([typ1, typ2, typ3, typ4, return]) <> ")"
     FunctionType([typ1, typ2, typ3, typ4, typ5], return) ->
       "types.IsFunction5("
-      <> type_args([typ1, typ2, typ3, typ4, typ5])
-      <> ", "
-      <> field_type(return)
+      <> type_args([typ1, typ2, typ3, typ4, typ5, return])
       <> ")"
     FunctionType([typ1, typ2, typ3, typ4, typ5, typ6], return) ->
       "types.IsFunction6("
-      <> type_args([typ1, typ2, typ3, typ4, typ5, typ6])
-      <> ", "
-      <> field_type(return)
+      <> type_args([typ1, typ2, typ3, typ4, typ5, typ6, return])
       <> ")"
     _ -> {
       io.debug(typ)

--- a/src/glerd/types.gleam
+++ b/src/glerd/types.gleam
@@ -3,6 +3,7 @@ pub type FieldType {
   IsInt
   IsFloat
   IsBool
+  IsNil
   IsList(FieldType)
   IsTuple2(FieldType, FieldType)
   IsTuple3(FieldType, FieldType, FieldType)
@@ -13,4 +14,19 @@ pub type FieldType {
   IsOption(FieldType)
   IsResult(FieldType, FieldType)
   IsRecord(String)
+  IsFunction0(FieldType)
+  IsFunction1(FieldType, FieldType)
+  IsFunction2(FieldType, FieldType, FieldType)
+  IsFunction3(FieldType, FieldType, FieldType, FieldType)
+  IsFunction4(FieldType, FieldType, FieldType, FieldType, FieldType)
+  IsFunction5(FieldType, FieldType, FieldType, FieldType, FieldType, FieldType)
+  IsFunction6(
+    FieldType,
+    FieldType,
+    FieldType,
+    FieldType,
+    FieldType,
+    FieldType,
+    FieldType,
+  )
 }


### PR DESCRIPTION
This pull request adds Function types Function0 (no arguments and a return), Function1 (1 argument and a return),  Function2 (2 argument and a return) and so on all up to 6 arguments and a Nil type.

Example output for function type
```gleam
types.IsFunction3(
    types.IsString, // Argument 1
    types.IsString, // Argument 2
    types.IsString, // Argument 3
    types.IsResult(types.IsString, types.IsString), // Return
),
```


Example output for Nil type
```gleam
types.IsNil
```